### PR TITLE
feat: sub multiple whitespace with single

### DIFF
--- a/extractnum/main.py
+++ b/extractnum/main.py
@@ -167,6 +167,9 @@ def main():
         current_line += 1
         if current_line < args.offset:
             continue
+        # Substitute multiple whitespace with single whitespace
+        _RE_COMBINE_WHITESPACE = re.compile(r"\s+")
+        line = _RE_COMBINE_WHITESPACE.sub(" ", line).strip()
         for p in patterns:
             result = p.search(line)
             if result is not None:

--- a/extractnum/main.py
+++ b/extractnum/main.py
@@ -160,6 +160,9 @@ def main():
             except re.error as e:
                 on_error(f"Cannot parse the plain pattern: '{p}'. Error: {str(e)}")
 
+    # Substitute multiple whitespace with single whitespace
+    _RE_COMBINE_WHITESPACE = re.compile(r"\s+")
+        
     # parse
     label_to_array = {}
     current_line = -1
@@ -167,8 +170,6 @@ def main():
         current_line += 1
         if current_line < args.offset:
             continue
-        # Substitute multiple whitespace with single whitespace
-        _RE_COMBINE_WHITESPACE = re.compile(r"\s+")
         line = _RE_COMBINE_WHITESPACE.sub(" ", line).strip()
         for p in patterns:
             result = p.search(line)


### PR DESCRIPTION
Thanks for your great CLI tool! When I use it for extracting arrays from log files, it is frequent that there are multiple whitespaces consisting of '\t', ' ', etc. in the content. Thus, adding a feature to remove their side-effect on pattern recognization may be helpful in improving user experience. (Or it can be an optional feature)